### PR TITLE
Bug correction

### DIFF
--- a/sqlitedict.py
+++ b/sqlitedict.py
@@ -214,8 +214,8 @@ class SqliteDict(object, DictMixin):
         try:
             if self.conn is not None:
                 if self.conn.autocommit:
-                    self.conn.conn.commit()
-                self.conn.conn.close()
+                    self.conn.commit()
+                self.conn.close()
                 self.conn = None
             if self.in_temp:
                 os.remove(self.filename)


### PR DESCRIPTION
Mistake in the destructor. self.conn.conn doesn't exist but self.conn is OK.
The SqliteMultithread didn't close. Then, you might have a sort of thread leak.
