### PR TITLE
Join thread after close()

### DIFF
--- a/sqlitedict.py
+++ b/sqlitedict.py
@@ -199,6 +199,7 @@ class SqliteDict(object, DictMixin):
             if self.conn.autocommit:
                 self.conn.commit()
             self.conn.close()
+            self.conn.join()
             self.conn = None
         if self.in_temp:
             try:
@@ -222,6 +223,7 @@ class SqliteDict(object, DictMixin):
                 if self.conn.autocommit:
                     self.conn.commit()
                 self.conn.close()
+                self.conn.join()
                 self.conn = None
             if self.in_temp:
                 os.remove(self.filename)


### PR DESCRIPTION
This prevents occasional errors on Python 2.7 when exiting the
program:

```
Exception in thread Thread-1 (most likely raised during interpreter shutdown):
Traceback (most recent call last):
    File "/usr/lib/python2.7/threading.py", line 552, in __bootstrap_inner
    File "/usr/local/lib/python2.7/dist-packages/sqlitedict.py", line 255, in run
    File "/usr/lib/python2.7/Queue.py", line 179, in get
    File "/usr/lib/python2.7/threading.py", line 279, in notify
    <type 'exceptions.TypeError'>: 'NoneType' object is not callable
```

As far as I know, these errors are benign, but it is good practice to always join your threads.
