### PR TITLE
Support filenames without an explicit path.

### DIFF
--- a/sqlitedict.py
+++ b/sqlitedict.py
@@ -87,8 +87,10 @@ class SqliteDict(object, DictMixin):
             if os.path.exists(filename):
                 os.remove(filename)
 
-        if not os.path.exists(os.path.dirname(filename)):
-            raise RuntimeError('Error! The directory does not exist, %s' % os.path.dirname(filename))
+        dirname = os.path.dirname(filename)
+        if dirname:
+            if not os.path.exists(dirname):
+                raise RuntimeError('Error! The directory does not exist, %s' % dirname)
 
         self.filename = filename
         self.tablename = tablename


### PR DESCRIPTION
os.path.dirname() returns an empty string if the filename argument has directory component.  os.path.exists() fails to find an empty path, so when doing SqliteDict("foo.db") you get an exception.

This commit changes the sanity check to support a filename without an explicit path component.
