### PR TITLE
support sqlitedict in memory

### DIFF
--- a/sqlitedict.py
+++ b/sqlitedict.py
@@ -36,7 +36,7 @@ from Queue import Queue
 from threading import Thread
 
 
-logger = logging.getLogger('sqlitedict')
+logger = logging.getLogger(__name__)
 
 
 
@@ -214,6 +214,10 @@ class SqliteDict(object, DictMixin):
     def terminate(self):
         """Delete the underlying database file. Use with care."""
         self.close()
+        
+        if self.filename == ':memory:':
+            return
+
         logger.info("deleting %s" % self.filename)
         try:
             os.remove(self.filename)

--- a/tests/test_named_db.py
+++ b/tests/test_named_db.py
@@ -13,6 +13,15 @@ def norm_file(fname):
     return fname
 
 
+class InMemorySqliteDictTest(TempSqliteDictTest):
+
+    def setUp(self):
+        self.d = sqlitedict.SqliteDict(filename=':memory:', autocommit=True)
+
+    def tearDown(self):
+        self.d.terminate()
+
+
 class NamedSqliteDictTest(TempSqliteDictTest):
 
     def setUp(self):
@@ -49,3 +58,5 @@ class SqliteDictAutocommitTest(TempSqliteDictTest):
 
     def tearDown(self):
         self.d.terminate()
+
+


### PR DESCRIPTION
To use just define filename as ':memory:'.

``` python
d=sqlitedict.SqliteDict(":memory:")
```
