### PR TITLE
Fixing bool(), MRO and License

### DIFF
--- a/sqlitedict.py
+++ b/sqlitedict.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# This code is distributed with Python Software Foundation License
-# https://www.python.org/download/releases/2.7/license/
+# This code is distributed under the terms and conditions
+# from the Apache License, Version 2.0
+#
+# http://opensource.org/licenses/apache2.0.php
 #
 # This code was inspired in the next publications:
 #  * http://code.activestate.com/recipes/576638-draft-for-an-sqlite3-based-dbm/


### PR DESCRIPTION
I didn't get the wa MAX(id) is faster than COUNT(*) if it needs to run and compare all values from the DB.
In the other hand I also fixes the MRO (it didn't complain in 2.X not sure why) and I added a license.

As far as I know many companies prefer to have a well known open source license which lets them work than just "public domain" which falls in a grey area which many lawyers do not recommend.
