### PR TITLE
Table name quoting

### DIFF
--- a/sqlitedict.py
+++ b/sqlitedict.py
@@ -151,6 +151,8 @@ class SqliteDict(DictClass):
                 raise RuntimeError('Error! The directory does not exist, %s' % dirname)
 
         self.filename = filename
+        if '"' in tablename:
+            raise ValueError('Invalid tablename %r' % tablename)
         self.tablename = tablename
 
         logger.info("opening Sqlite table %r in %s" % (tablename, filename))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -144,6 +144,9 @@ class NamedSqliteDictCreateOrReuseTest(TempSqliteDictTest):
         self.assertEqual(db['key'], 'value')
         db.close()
 
+        self.assertRaisesRegexp(ValueError, r'^Invalid tablename ',
+                                sqlitedict.SqliteDict, ':memory:', '"')
+
     def test_overwrite_using_flag_w(self):
         """Re-opening of a database with flag='w' destroys only the target table."""
         # given,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -130,6 +130,20 @@ class NamedSqliteDictCreateOrReuseTest(TempSqliteDictTest):
             with self.assertRaises(RuntimeError):
                 func()
 
+    def test_irregular_tablenames(self):
+        """Irregular table names need to be quoted"""
+        db = sqlitedict.SqliteDict(':memory:', tablename='9nine')
+        db['key'] = 'value'
+        db.commit()
+        self.assertEqual(db['key'], 'value')
+        db.close()
+
+        db = sqlitedict.SqliteDict(':memory:', tablename='outer space')
+        db['key'] = 'value'
+        db.commit()
+        self.assertEqual(db['key'], 'value')
+        db.close()
+
     def test_overwrite_using_flag_w(self):
         """Re-opening of a database with flag='w' destroys only the target table."""
         # given,


### PR DESCRIPTION
Tables names that don't start with a letter or aren't alphanumeric
need to be enclosed in double quotes.