### PR TITLE
commit before turning off synchronous

### DIFF
--- a/sqlitedict.py
+++ b/sqlitedict.py
@@ -368,6 +368,7 @@ class SqliteMultithread(Thread):
         conn.execute('PRAGMA journal_mode = %s' % self.journal_mode)
         conn.text_factory = str
         cursor = conn.cursor()
+        conn.commit()
         cursor.execute('PRAGMA synchronous=OFF')
 
         res = None


### PR DESCRIPTION
otherwise python 3.6 fails with
sqlite3.OperationalError: Safety level may not be changed inside a transaction
(fixes issue #58)