### PR TITLE
Update sqlite version to 3.8.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,12 @@ python:
   - "3.3"
   - "2.7"
   - "2.6"
+addons:
+   apt:
+     sources:
+       - travis-ci/sqlite3
+     packages:
+       - sqlite3
 install: 
   - python setup.py install
   - python -c "import sqlite3 as sqlite; print(sqlite.sqlite_version)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: false
+dist: trusty
 language: python
 notifications:
   email: false
@@ -9,12 +10,6 @@ python:
   - "3.3"
   - "2.7"
   - "2.6"
-addons:
-   apt:
-     sources:
-       - travis-ci/sqlite3
-     packages:
-       - sqlite3
 install: 
   - python setup.py install
   - python -c "import sqlite3 as sqlite; print(sqlite.sqlite_version)"


### PR DESCRIPTION
Helps detect bugs like https://github.com/RaRe-Technologies/sqlitedict/issues/58

Option 1. Install sqlite 3.7.15 from ppa
Option 2. Use Travis Ubuntu Trusty env with 3.8 version of sqlite.