### PR TITLE
Replace easy_install installation with pip

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,7 +81,7 @@ The module has no dependencies beyond Python itself. The minimum Python version 
 
 Install or upgrade with::
 
-    pip -U sqlitedict
+    pip install -U sqlitedict
 
 or from the `source tar.gz <http://pypi.python.org/pypi/sqlitedict>`_::
 

--- a/README.rst
+++ b/README.rst
@@ -81,7 +81,7 @@ The module has no dependencies beyond Python itself. The minimum Python version 
 
 Install or upgrade with::
 
-    easy_install -U sqlitedict
+    pip -U sqlitedict
 
 or from the `source tar.gz <http://pypi.python.org/pypi/sqlitedict>`_::
 


### PR DESCRIPTION
Update readme to use pip for installation instead of easy_install as it is probably deprecated.