### PR TITLE
Fix interrupted iteration over a SqliteDict instance

### DIFF
--- a/sqlitedict.py
+++ b/sqlitedict.py
@@ -594,7 +594,7 @@ class SqliteMultithread(Thread):
         raise TimeoutError("SqliteMultithread failed to flag initialization withing %0.0f seconds." % self.timeout)
 
 
-class _CancelableQueue(Queue):
+class _CancelableQueue(Queue, object):
     def __init__(self, *args, **kwargs):
         super(_CancelableQueue, self).__init__(*args, **kwargs)
         self.is_canceled = False

--- a/sqlitedict.py
+++ b/sqlitedict.py
@@ -595,7 +595,7 @@ class SqliteMultithread(Thread):
 
 
 class _CancelableQueue(Queue):
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args, **kwargs):
         super(Queue, self).__init__(*args, **kwargs)
         self.is_canceled = False
 
@@ -608,7 +608,7 @@ class _CancelableQueue(Queue):
 
 
 class _QueueReader:
-    def __init__(self, owner, queue) -> None:
+    def __init__(self, owner, queue):
         self._owner = owner
         self._queue = queue
 

--- a/sqlitedict.py
+++ b/sqlitedict.py
@@ -596,7 +596,7 @@ class SqliteMultithread(Thread):
 
 class _CancelableQueue(Queue):
     def __init__(self, *args, **kwargs):
-        super(Queue, self).__init__(*args, **kwargs)
+        super(_CancelableQueue, self).__init__(*args, **kwargs)
         self.is_canceled = False
 
     def cancel(self):
@@ -604,7 +604,7 @@ class _CancelableQueue(Queue):
 
     def put(self, value):
         if not self.is_canceled:
-            super(Queue, self).put(value)
+            super(_CancelableQueue, self).put(value)
 
 
 class _QueueReader:

--- a/sqlitedict.py
+++ b/sqlitedict.py
@@ -617,8 +617,8 @@ class _QueueReader:
         self._queue.cancel()
 
     def read(self):
-        while True:
-            rec = self.get()
+        while not self._queue.is_canceled:
+            rec = self._queue.get()
             self._owner.check_raise_error()
             if rec == '--no more--':
                 break


### PR DESCRIPTION
Fixes #69.

When GC collected the `_QueueReader`, the `_CancelableQueue` will mark as canceled, so no more new items can be added to the queue.