### PR TITLE
Use setuptools instead of distutils which is deprecated in Python 3.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ import io
 import subprocess
 
 import setuptools.command.develop
-from distutils.core import setup
+from setuptools import setup
 
 
 def read(fname):


### PR DESCRIPTION
Fixes #142 