### PR TITLE
Fix interrupted iteration over a SqliteDict instance

### DIFF
--- a/sqlitedict.py
+++ b/sqlitedict.py
@@ -533,9 +533,9 @@ class SqliteMultithread(Thread):
                     for rec in cursor:
                         if _put(res_ref, rec) == _PUT_REFERENT_DESTROYED:
                             #
-                            # The queue we are sending responses to got
-                            # garbage collected, so we stop processing the
-                            # commands.
+                            # The queue we are sending responses to got garbage
+                            # collected.  Nobody is listening anymore, so we
+                            # stop sending responses.
                             #
                             break
 

--- a/tests/test_autocommit.py
+++ b/tests/test_autocommit.py
@@ -6,7 +6,7 @@ import sqlitedict
 
 def test():
     "Verify autocommit just before program exits."
-    assert os.system('PYTHONPATH=. %s tests/autocommit.py' % sys.executable) == 0
+    assert os.system('env PYTHONPATH=. %s tests/autocommit.py' % sys.executable) == 0
     # The above script relies on the autocommit feature working correctly.
     # Now, let's check if it actually worked.
     d = sqlitedict.SqliteDict('tests/db/autocommit.sqlite')


### PR DESCRIPTION
Fixes #69, with `weakref` reader queue.

Fix maybe #48?