### PR TITLE
Fix setDaemon deprecated warning

### DIFF
--- a/sqlitedict.py
+++ b/sqlitedict.py
@@ -378,10 +378,7 @@ class SqliteMultithread(Thread):
         self.journal_mode = journal_mode
         # use request queue of unlimited size
         self.reqs = Queue()
-        if sys.version_info.major == 3:
-            self.daemon = True  # python 3.x compatible
-        else:
-            self.setDaemon(True)  # python2.5-compatible
+        self.daemon = True
         self.exception = None
         self._sqlitedict_thread_initialized = None
         self._outer_stack = outer_stack

--- a/sqlitedict.py
+++ b/sqlitedict.py
@@ -378,7 +378,10 @@ class SqliteMultithread(Thread):
         self.journal_mode = journal_mode
         # use request queue of unlimited size
         self.reqs = Queue()
-        self.setDaemon(True)  # python2.5-compatible
+        if sys.version_info.major == 3:
+            self.daemon = True  # python 3.x compatible
+        else:
+            self.setDaemon(True)  # python2.5-compatible
         self.exception = None
         self._sqlitedict_thread_initialized = None
         self._outer_stack = outer_stack


### PR DESCRIPTION
fixes #156 

I've added a check for python version so that the deprecated syntax is still used for python 2.x to keep backwards compatibility.