### PR TITLE
adding optional (not enabled by default) ability to encode keys

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -147,6 +147,15 @@ It's possible to use a custom (de)serializer, notably for JSON and for compressi
     >>> with SqliteDict("example.sqlite", encode=my_encode, decode=my_decode) as mydict:
     ...     pass
 
+It's also possible to use a custom (de)serializer for keys to allow non-string keys.
+
+.. code-block:: python
+
+    >>> # Use key encoding instead of default string keys only
+    >>> from sqlitedict import encode_key, decode_key
+    >>> with SqliteDict("example.sqlite", encode_key=encode_key, decode_key=decode_key) as mydict:
+    ...     pass
+
 More
 ----
 

--- a/sqlitedict.py
+++ b/sqlitedict.py
@@ -33,6 +33,7 @@ import tempfile
 import logging
 import time
 import traceback
+from base64 import b64decode, b64encode
 
 from threading import Thread
 
@@ -81,13 +82,27 @@ def decode(obj):
     """Deserialize objects retrieved from SQLite."""
     return loads(bytes(obj))
 
+def encode_key(key):
+    """Serialize a key using pickle + base64 encoding to text accepted by SQLite."""
+    return b64encode(dumps(key, protocol=PICKLE_PROTOCOL)).decode("ascii")
+
+def decode_key(key):
+    """Deserialize a key retrieved from SQLite."""
+    return loads(b64decode(key.encode("ascii")))
+
+def identity(obj):
+    """Identity f(x) = x function for encoding/decoding."""
+    return obj
+
 
 class SqliteDict(DictClass):
     VALID_FLAGS = ['c', 'r', 'w', 'n']
 
     def __init__(self, filename=None, tablename='unnamed', flag='c',
                  autocommit=False, journal_mode="DELETE", encode=encode,
-                 decode=decode, timeout=5, outer_stack=True):
+                 #decode=decode, encode_key=identity, decode_key=identity, 
+                 decode=decode, encode_key=identity, decode_key=identity, 
+                 timeout=5, outer_stack=True):
         """
         Initialize a thread-safe sqlite-backed dictionary. The dictionary will
         be a table `tablename` in database file `filename`. A single file (=database)
@@ -153,6 +168,8 @@ class SqliteDict(DictClass):
         self.journal_mode = journal_mode
         self.encode = encode
         self.decode = decode
+        self.encode_key = encode_key
+        self.decode_key = decode_key
         self.timeout = timeout
         self._outer_stack = outer_stack
 
@@ -212,7 +229,7 @@ class SqliteDict(DictClass):
     def iterkeys(self):
         GET_KEYS = 'SELECT key FROM "%s" ORDER BY rowid' % self.tablename
         for key in self.conn.select(GET_KEYS):
-            yield key[0]
+            yield self.decode_key(key[0])
 
     def itervalues(self):
         GET_VALUES = 'SELECT value FROM "%s" ORDER BY rowid' % self.tablename
@@ -222,7 +239,7 @@ class SqliteDict(DictClass):
     def iteritems(self):
         GET_ITEMS = 'SELECT key, value FROM "%s" ORDER BY rowid' % self.tablename
         for key, value in self.conn.select(GET_ITEMS):
-            yield key, self.decode(value)
+            yield self.decode_key(key), self.decode(value)
 
     def keys(self):
         return self.iterkeys()
@@ -235,11 +252,11 @@ class SqliteDict(DictClass):
 
     def __contains__(self, key):
         HAS_ITEM = 'SELECT 1 FROM "%s" WHERE key = ?' % self.tablename
-        return self.conn.select_one(HAS_ITEM, (key,)) is not None
+        return self.conn.select_one(HAS_ITEM, (self.encode_key(key),)) is not None
 
     def __getitem__(self, key):
         GET_ITEM = 'SELECT value FROM "%s" WHERE key = ?' % self.tablename
-        item = self.conn.select_one(GET_ITEM, (key,))
+        item = self.conn.select_one(GET_ITEM, (self.encode_key(key),))
         if item is None:
             raise KeyError(key)
         return self.decode(item[0])
@@ -249,7 +266,7 @@ class SqliteDict(DictClass):
             raise RuntimeError('Refusing to write to read-only SqliteDict')
 
         ADD_ITEM = 'REPLACE INTO "%s" (key, value) VALUES (?,?)' % self.tablename
-        self.conn.execute(ADD_ITEM, (key, self.encode(value)))
+        self.conn.execute(ADD_ITEM, (self.encode_key(key), self.encode(value)))
         if self.autocommit:
             self.commit()
 
@@ -260,7 +277,7 @@ class SqliteDict(DictClass):
         if key not in self:
             raise KeyError(key)
         DEL_ITEM = 'DELETE FROM "%s" WHERE key = ?' % self.tablename
-        self.conn.execute(DEL_ITEM, (key,))
+        self.conn.execute(DEL_ITEM, (self.encode_key(key),))
         if self.autocommit:
             self.commit()
 
@@ -272,7 +289,7 @@ class SqliteDict(DictClass):
             items = items.items()
         except AttributeError:
             pass
-        items = [(k, self.encode(v)) for k, v in items]
+        items = [(self.encode_key(k), self.encode(v)) for k, v in items]
 
         UPDATE_ITEMS = 'REPLACE INTO "%s" (key, value) VALUES (?, ?)' % self.tablename
         self.conn.executemany(UPDATE_ITEMS, items)

--- a/sqlitedict.py
+++ b/sqlitedict.py
@@ -100,7 +100,6 @@ class SqliteDict(DictClass):
 
     def __init__(self, filename=None, tablename='unnamed', flag='c',
                  autocommit=False, journal_mode="DELETE", encode=encode,
-                 #decode=decode, encode_key=identity, decode_key=identity, 
                  decode=decode, encode_key=identity, decode_key=identity, 
                  timeout=5, outer_stack=True):
         """

--- a/sqlitedict.py
+++ b/sqlitedict.py
@@ -82,13 +82,16 @@ def decode(obj):
     """Deserialize objects retrieved from SQLite."""
     return loads(bytes(obj))
 
+
 def encode_key(key):
     """Serialize a key using pickle + base64 encoding to text accepted by SQLite."""
     return b64encode(dumps(key, protocol=PICKLE_PROTOCOL)).decode("ascii")
 
+
 def decode_key(key):
     """Deserialize a key retrieved from SQLite."""
     return loads(b64decode(key.encode("ascii")))
+
 
 def identity(obj):
     """Identity f(x) = x function for encoding/decoding."""
@@ -100,7 +103,7 @@ class SqliteDict(DictClass):
 
     def __init__(self, filename=None, tablename='unnamed', flag='c',
                  autocommit=False, journal_mode="DELETE", encode=encode,
-                 decode=decode, encode_key=identity, decode_key=identity, 
+                 decode=decode, encode_key=identity, decode_key=identity,
                  timeout=5, outer_stack=True):
         """
         Initialize a thread-safe sqlite-backed dictionary. The dictionary will

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -297,11 +297,12 @@ class TablenamesTest(unittest.TestCase):
         tablenames = SqliteDict.get_tablenames('tests/db/tablenames-test-2.sqlite')
         self.assertEqual(tablenames, ['table1', 'table2'])
 
+
 class SqliteDictKeySerializationTest(unittest.TestCase):
     def setUp(self):
         self.fname = norm_file('tests/db-encode-key/sqlitedict.sqlite')
         self.db = SqliteDict(
-            filename=self.fname, tablename='test', 
+            filename=self.fname, tablename='test',
             encode_key=sqlitedict.encode_key, decode_key=sqlitedict.decode_key,
         )
 
@@ -310,4 +311,3 @@ class SqliteDictKeySerializationTest(unittest.TestCase):
         assert self.db['test'] == -42
         self.db[(0, 1, 2)] = 17
         assert self.db[(0, 1, 2)] == 17
-

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -248,7 +248,7 @@ class SqliteDictJsonSerializationTest(unittest.TestCase):
         os.rmdir(os.path.dirname(self.fname))
 
     def get_json(self, key):
-        return self.db.conn.select_one('SELECT value FROM test WHERE key = ?', (key,))[0]
+        return self.db.conn.select_one('SELECT value FROM test WHERE key = ?', (self.db.encode_key(key),))[0]
 
     def test_int(self):
         self.db['test'] = -42
@@ -296,3 +296,18 @@ class TablenamesTest(unittest.TestCase):
 
         tablenames = SqliteDict.get_tablenames('tests/db/tablenames-test-2.sqlite')
         self.assertEqual(tablenames, ['table1', 'table2'])
+
+class SqliteDictKeySerializationTest(unittest.TestCase):
+    def setUp(self):
+        self.fname = norm_file('tests/db-encode-key/sqlitedict.sqlite')
+        self.db = SqliteDict(
+            filename=self.fname, tablename='test', 
+            encode_key=sqlitedict.encode_key, decode_key=sqlitedict.decode_key,
+        )
+
+    def test_nonstr_keys(self):
+        self.db['test'] = -42
+        assert self.db['test'] == -42
+        self.db[(0, 1, 2)] = 17
+        assert self.db[(0, 1, 2)] == 17
+


### PR DESCRIPTION
This pull requests adds the optional behavior of encoding keys.

The justification: support for hashable, but not `str` (or `int`) keys, e.g. `tuple` as a key.

The changes include:
- the core class now allows passing `encode_key` and `decode_key` method
- both of these methods are the identity function by default
- the module now provides two default `encode_key` and `decode_key` which are base64 encoding of pickle dump of key
- the changes do not change the sqlite key type: TEXT
- the changes are tested, I added a test for a tuple key

Potential problems:
- the optional key encoding using pickle serialization, so it allows non-hashable types to act as keys