### PR TITLE
Properly handle the race condition

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,7 +19,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Update pip
-        run: python -m pip install -U coverage flake8 pip pytest pytest-coverage
+        run: python -m pip install -U coverage flake8 pip pytest pytest-coverage pytest-benchmark
 
       - name: Flake8
         run: flake8 sqlitedict.py tests
@@ -34,6 +34,9 @@ jobs:
 
       - name: Run tests
         run: pytest tests --cov=sqlitedict
+
+      - name: Run benchmarks
+        run: pytest benchmarks
 
       - name: Run doctests
         run: python -m doctest README.rst

--- a/benchmarks/test_insert.py
+++ b/benchmarks/test_insert.py
@@ -1,0 +1,15 @@
+import tempfile
+
+from sqlitedict import SqliteDict
+
+
+def insert():
+    with tempfile.NamedTemporaryFile() as tmp:
+        for j in range(100):
+            with SqliteDict(tmp.name) as d:
+                d["tmp"] = j
+                d.commit()
+
+
+def test(benchmark):
+    benchmark(insert)

--- a/sqlitedict.py
+++ b/sqlitedict.py
@@ -399,16 +399,16 @@ class SqliteMultithread(threading.Thread):
 
         #
         # Parts of this object's state get accessed from different threads, so
-        # we use synchronization to avoid race conditions.  For example, the
-        # .exception and ._sqlite_thread_initialized are set inside the new
-        # daemon thread that we spawned, but they get read from the main
-        # thread.  This is particularly important during initialization: the
-        # Thread needs some time to actually start working, and until this
-        # happens, any calls to e.g. check_raise_error() will prematurely
-        # return None, meaning all is well.  If the that connection happens to
-        # fail, we'll never know about it, and instead wait for a result that
-        # never arrives (effectively, deadlocking).  Locking solves this
-        # problem by eliminating the race condition.
+        # we use synchronization to avoid race conditions.  For example,
+        # .exception gets set inside the new daemon thread that we spawned, but
+        # gets read from the main thread.  This is particularly important
+        # during initialization: the Thread needs some time to actually start
+        # working, and until this happens, any calls to e.g.
+        # check_raise_error() will prematurely return None, meaning all is
+        # well.  If the that connection happens to fail, we'll never know about
+        # it, and instead wait for a result that never arrives (effectively,
+        # deadlocking).  Locking solves this problem by eliminating the race
+        # condition.
         #
         self._lock = threading.Lock()
         self._lock.acquire()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -282,12 +282,18 @@ class SqliteDictJsonSerializationTest(unittest.TestCase):
 
 
 class TablenamesTest(unittest.TestCase):
+    def tearDown(self):
+        for f in ('tablenames-test-1.sqlite', 'tablenames-test-2.sqlite'):
+            path = norm_file(os.path.join('tests/db', f))
+            if os.path.isfile(path):
+                os.unlink(path)
 
-    def test_tablenames(self):
+    def test_tablenames_unnamed(self):
         fname = norm_file('tests/db/tablenames-test-1.sqlite')
         SqliteDict(fname)
         self.assertEqual(SqliteDict.get_tablenames(fname), ['unnamed'])
 
+    def test_tablenams_named(self):
         fname = norm_file('tests/db/tablenames-test-2.sqlite')
         with SqliteDict(fname, tablename='table1'):
             self.assertEqual(SqliteDict.get_tablenames(fname), ['table1'])


### PR DESCRIPTION
Use synchronization primitives instead of sleeping. This eliminates the need for the timeout parameter. The affected class is effectively internal, so this "should" not affect regular users.

Also fixed the tests: they didn't clean up after themselves.

Added benchmarks.

Fixes #152